### PR TITLE
[hot-fix] 빈 순환 참조 문제 해결

### DIFF
--- a/src/main/java/io/github/jeli01/kakao_bootcamp_community/auth/config/BCryptConfig.java
+++ b/src/main/java/io/github/jeli01/kakao_bootcamp_community/auth/config/BCryptConfig.java
@@ -1,0 +1,13 @@
+package io.github.jeli01.kakao_bootcamp_community.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class BCryptConfig {
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/io/github/jeli01/kakao_bootcamp_community/auth/config/SecurityConfig.java
+++ b/src/main/java/io/github/jeli01/kakao_bootcamp_community/auth/config/SecurityConfig.java
@@ -17,7 +17,6 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
@@ -34,11 +33,6 @@ public class SecurityConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
-    }
-
-    @Bean
-    public BCryptPasswordEncoder bCryptPasswordEncoder() {
-        return new BCryptPasswordEncoder();
     }
 
     @Bean


### PR DESCRIPTION
Security Config와 UserService 간의 순환 참조 해결
Bcrypt 빈을 분리하여 문제를 해결하였다.